### PR TITLE
docs: fix typo Doker -> Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ For Apache do virtualhost with cgi-bin. Like this:
         </FilesMatch>
 </VirtualHost>
 ```
-# Doker
+# Docker
 ```
 docker service create --detach=false --name haproxy-wi --mount type=volume,src=haproxy-wi,dst=/var/www/haproxy-wi/app -p 8080:80 aidaho/haproxy-wi
 ```


### PR DESCRIPTION
Fix typo in README.md: Doker -> Docker