### PR TITLE
Catch the throw exception in variable e

### DIFF
--- a/app/delver.py
+++ b/app/delver.py
@@ -54,7 +54,7 @@ if serv is not None and form.getvalue('open') is not None:
 					os.remove(os.path.join(hap_configs_dir, form.getvalue(get)))
 					file.add(form.getvalue(get) + "<br />")
 					funct.logging(serv, "delver.py deleted config: %s" % form.getvalue(get))				
-				except OSError: 
+				except OSError as e: 
 					stderr = "Error: %s - %s." % (e.filename,e.strerror)
 		print('<meta http-equiv="refresh" content="10; url=delver.py?serv=%s&open=open">' % form.getvalue('serv'))		
 		


### PR DESCRIPTION
The next line refers to __e__ twice but it is never defined.

flake8 testing of https://github.com/Aidaho12/haproxy-wi on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./app/delver.py:58:36: F821 undefined name 'e'
					stderr = "Error: %s - %s." % (e.filename,e.strerror)
                                   ^
./app/delver.py:58:47: F821 undefined name 'e'
					stderr = "Error: %s - %s." % (e.filename,e.strerror)
                                              ^
2     F821 undefined name 'e'
2
```