### PR TITLE
Change requirement dump==0.0.3 to dump ==0.0.4 to fix install on py3k.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pytz==2017.3
 requests==2.18.4
 requests_toolbelt==0.8.0
 pyTelegramBotAPI==3.6.3 
-dump==0.0.3
+dump==0.0.4
 networkx==2.1
 numpy==1.14.0
 matplotlib==2.1.2


### PR DESCRIPTION
Now installs without errors on my readynas os 6.9, (arm 32bit).