### PR TITLE
Initialize oldstat at the top of the function

### DIFF
--- a/app/tools/checker_worker.py
+++ b/app/tools/checker_worker.py
@@ -22,6 +22,7 @@ def main(serv, port):
 	port = str(port)
 	firstrun = True
 	currentstat = []
+	oldstat = []
 	readstats = ""
 	killer = GracefulKiller()
 	old_stat_service = ""


### PR DESCRIPTION
It is not essential but it is safer if the code is changed in the future...

[flake8](http://flake8.pycqa.org) testing of https://github.com/Aidaho12/haproxy-wi on Python 3.7.0

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./app/tools/checker_worker.py:70:27: F821 undefined name 'oldstat'
				if (currentstat[i] != oldstat[i] and currentstat[i]!="none") and ("FRONTEND" not in str(vips[i]) and "BACKEND" not in str(vips[i])):
                          ^
1     F821 undefined name 'oldstat'
1
```