### PR TITLE
Replace mistakes with rsyslog config

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The installer will ask you a few questions
 $ git clone https://github.com/Aidaho12/haproxy-wi.git /var/www/haproxy-wi
 $ cd /var/www/haproxy-wi
 $ chmod +x install.sh
-$ sudo ./install
+$ sudo ./install.sh
 ```
 ## Manual install
 For install just clone:

--- a/install.sh
+++ b/install.sh
@@ -175,10 +175,11 @@ TimeoutStopSec=1s
 WantedBy=multi-user.target
 EOF
 
-cat << EOF > /etc/rsyslog.d/checker.conf 
-if $programname startswith 'checker' then /var/www/$HOME_HAPROXY_WI/log/checker-error.log
+cat << 'EOF' > /etc/rsyslog.d/checker.conf 
+if $programname startswith 'checker' then /var/www/__HOME_HAPROXY_WI__/log/checker-error.log
 & stop
 EOF
+sed -i -e "s/__HOME_HAPROXY_WI__/$HOME_HAPROXY_WI/g" /etc/rsyslog.d/checker.conf 
 
 cat << EOF > /etc/logrotate.d/checker
 /var/www/$HOME_HAPROXY_WI/log/checker-error.log {
@@ -214,10 +215,11 @@ TimeoutStopSec=1s
 WantedBy=multi-user.target
 EOF
 
-cat << EOF > /etc/rsyslog.d/metrics.conf 
-if $programname startswith 'metrics' then /var/www/$HOME_HAPROXY_WI/log/metrics-error.log
+cat << 'EOF' > /etc/rsyslog.d/metrics.conf 
+if $programname startswith 'metrics' then /var/www/__HOME_HAPROXY_WI__/log/metrics-error.log
 & stop
 EOF
+sed -i -e "s/__HOME_HAPROXY_WI__/$HOME_HAPROXY_WI/g" /etc/rsyslog.d/metrics.conf
 
 cat << EOF > /etc/logrotate.d/metrics
 /var/www/$HOME_HAPROXY_WI/log/metrics-error.log {


### PR DESCRIPTION
Hi there.
Sorry for "pull request" without issuing an "issue". &  Sorry for two consecutive days...

Replacement mistake with checker.conf & metrics.conf 
After runnning "install.sh"  the server, it was the following
```
# cat /etc/rsyslog.d/metrics.conf
if  startswith 'metrics' then /var/www/haproxy-wi/log/metrics-error.log
& stop

# cat /etc/rsyslog.d/checker.conf
if  startswith 'checker' then /var/www/haproxy-wi/log/checker-error.log
& stop
```
I think that  "$programname"  was treated as a variable

I'm sorry, can you confirm it?
If there is any other good ideas, please correct it !

