### PR TITLE
Add ability to test the configuration without saving

### DIFF
--- a/app/funct.py
+++ b/app/funct.py
@@ -343,7 +343,9 @@ def upload_and_restart(serv, cfg, **kwargs):
 		else:
 			commands = [ "sudo mv -f " + tmp_file + " /etc/keepalived/keepalived.conf && sudo systemctl restart keepalived" ]
 	else:
-		if kwargs.get("just_save") == "save":
+		if kwargs.get("just_save") == "test":
+			commands = [ "sudo haproxy  -q -c -f " + tmp_file + "&& sudo rm -f " + tmp_file ]
+		elif kwargs.get("just_save") == "save":
 			commands = [ "sudo haproxy  -q -c -f " + tmp_file + "&& sudo mv -f " + tmp_file + " " + sql.get_setting('haproxy_config_path') ]
 		else:
 			commands = [ "sudo haproxy  -q -c -f " + tmp_file + "&& sudo mv -f " + tmp_file + " " + sql.get_setting('haproxy_config_path') + " && sudo " + sql.get_setting('restart_command') ]	

--- a/app/templates/config.html
+++ b/app/templates/config.html
@@ -60,6 +60,7 @@
 					<input type="hidden" value="{{ cfg }}.old" name="oldconfig"> 
 					<textarea name="config" class="config" rows="35" cols="100">{{ config }}</textarea> 
 					<p>
+						<button type="submit" value="test" name="save" class="btn btn-default">Just test</button>
 						<button type="submit" value="save" name="save" class="btn btn-default">Just save</button>
 						<button type="submit" value="" name="" class="btn btn-default">Save and restart</button>
 					</p>


### PR DESCRIPTION
Hello, this PR adds the ability to test the configuration without saving it in the server.
We need this change because we are setting an automated process to change server configurations using our build processes.

We can't use the previous option of saving without restart because it would leave the config in the server which could lead to an unexpected configuration change in the chance of a server restart.

If/when this PR is merged a new docker tag will also be needed from the [Aidaho12/haproxy-wi-docker](https://github.com/Aidaho12/haproxy-wi-docker) repository.

I hope this change is in-line with the project. 🙂