### PR TITLE
ansible: fix logging

### DIFF
--- a/app/options.py
+++ b/app/options.py
@@ -614,8 +614,6 @@ if form.getvalue('master'):
 	else:
 		for l in output:
 			if "msg" in l or "FAILED" in l:
-				l = l.split(':')[1]
-				l = l.split('"')[1]
 				print(l+"<br>")
 				break
 		else:
@@ -639,8 +637,6 @@ if form.getvalue('master'):
 	else:
 		for l in output:
 			if "msg" in l or "FAILED" in l:
-				l = l.split(':')[1]
-				l = l.split('"')[1]
 				print(l+"<br>")
 				break
 		else:


### PR DESCRIPTION
It's better not to split error message to avoid these errors:

> Wed Nov 27 15:03:13.943111 2019] [cgi:error] [pid 5819] [client x.x.x.x:9780] AH01215:   File "/var/www/haproxy-wi/app/options.py", line 643, in <module>: /var/www/haproxy-wi/app/options.py, referer: https://y.y.y.y/app/ha.py
> [Wed Nov 27 15:03:13.943143 2019] [cgi:error] [pid 5819] [client x.x.x.x:9780] AH01215:     l = l.split('"')[1]: /var/www/haproxy-wi/app/options.py, referer: https://y.y.y.y/app/ha.py
> [Wed Nov 27 15:03:13.943187 2019] [cgi:error] [pid 5819] [client x.x.x.x:9780] AH01215: IndexError: list index out of range: /var/www/haproxy-wi/app/options.py, referer: https://y.y.y.y/app/ha.py
