### PR TITLE
keepalived: replace pidof by pgrep

### DIFF
--- a/app/scripts/ansible/roles/keepalived/templates/keepalived.conf.j2
+++ b/app/scripts/ansible/roles/keepalived/templates/keepalived.conf.j2
@@ -3,7 +3,7 @@ global_defs {
 }
 #health-check for keepalive
 vrrp_script chk_haproxy { 
-    script "pidof haproxy"
+    script "pgrep haproxy"
     interval 2
     weight 3 
 }


### PR DESCRIPTION
This is to avoid the following error message:
`killall5: only one argument, a signal number, allowed`
'systemctl status haproxy' should also work.